### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+imageio
+pillow


### PR DESCRIPTION
I have added a requirements.txt file so now dependencies can be installed directly by executing `pip install -r requirements.txt` 